### PR TITLE
Fixed min-height on iframe after load

### DIFF
--- a/apps/web-player/src/player/index.js
+++ b/apps/web-player/src/player/index.js
@@ -47,6 +47,7 @@ export const create = async (config, target) => {
       })
     )
     .then(resize(target.node))
+    .then(setStyles({ 'min-height': null }, target.node))
 
   setAccessibilityAttributes(config, player)
 


### PR DESCRIPTION
If the player has some elements disabled, after it loads the min-height attribute causes a band of blank space below the rendered player due to the min-height attribute being set statically.# Please enter the commit message for your changes. Lines starting

This addresses #98 