### PR TITLE
Correct markdown link

### DIFF
--- a/docs/web-player/installation.md
+++ b/docs/web-player/installation.md
@@ -38,4 +38,4 @@ To integrate the player you first have to install tha package:
 npm install @podlove/web-player --save
 ```
 
-Move the player assets to some public folder of your webserver. By default the player will try to load further chunks from the webserver base. If the player files are located in a subpath you have to adapt the `base` accordingly (see [config]({{ $withBase('config.html') }})
+Move the player assets to some public folder of your webserver. By default the player will try to load further chunks from the webserver base. If the player files are located in a subpath you have to adapt the `base` accordingly (see [config](config.html)


### PR DESCRIPTION
`$withBase` is processed after the markdown rendering which then in part doesn't create a link out of `[]()`. So According to the docs this link should work and does for local deployment.

I'm not 100% sure that it will work for deployment as well. If not this should be 
```
<a :href=$withBase('config.html')>config</a>
```