### PR TITLE
Remove min-height attribute from wrapper

### DIFF
--- a/apps/player/package.json
+++ b/apps/player/package.json
@@ -32,7 +32,7 @@
     "ramda": "0.26.1",
     "redux": "4.0.1",
     "redux-vuex": "0.1.3",
-    "vue": "2.6.10",
+    "vue": "2.6.11",
     "vue-i18n": "8.11.1"
   },
   "devDependencies": {

--- a/apps/player/src/Wrapper.vue
+++ b/apps/player/src/Wrapper.vue
@@ -27,7 +27,6 @@ export default {
   width: 100%;
   max-width: $width-xl;
   min-width: $width-xs;
-  min-height: 250px;
 
   @include font();
   font-size: 14px;

--- a/apps/subscribe-button/package.json
+++ b/apps/subscribe-button/package.json
@@ -21,7 +21,7 @@
     "redux": "4.0.1",
     "redux-actions": "2.6.4",
     "redux-vuex": "0.1.3",
-    "vue": "2.6.10",
+    "vue": "2.6.11",
     "vue-i18n": "^8.11.1"
   },
   "devDependencies": {

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -43,7 +43,7 @@
     "sass-loader": "7.1.0",
     "vue-i18n": "^8.11.1",
     "vue-loader": "15.4.2",
-    "vue-template-compiler": "2.6.10",
+    "vue-template-compiler": "2.6.11",
     "webpack": "4.26.0",
     "webpack-auto-inject-version": "1.2.2",
     "webpack-bundle-analyzer": "3.0.3",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -21,7 +21,7 @@
     "@podlove/utils": "^4.5.10",
     "normalize.css": "8.0.1",
     "v-tooltip": "2.0.0-rc.33",
-    "vue": "2.6.10"
+    "vue": "2.6.11"
   },
   "devDependencies": {
     "@podlove/build": "^4.5.10",


### PR DESCRIPTION
The min-height setting causes whitespace to be displayed at the bottom of the player if some of the UI elements are disabled.