### PR TITLE
fix: include protocol in doc links

### DIFF
--- a/docs/web-player/index.md
+++ b/docs/web-player/index.md
@@ -18,6 +18,6 @@ navigation: 1
 
 ## Previous Versions
 
-- [Podlove Web Player v4 Docs](//docs.podlove.org/podlove-web-player-v4/)
-- [Podlove Web Player v3 Docs](//docs.podlove.org/podlove-web-player-v3/)
-- [Podlove Web Player v2 Docs](//docs.podlove.org/podlove-web-player-v3/versions/v2.html)
+- [Podlove Web Player v4 Docs](https://docs.podlove.org/podlove-web-player-v4/)
+- [Podlove Web Player v3 Docs](https://docs.podlove.org/podlove-web-player-v3/)
+- [Podlove Web Player v2 Docs](https://docs.podlove.org/podlove-web-player-v3/versions/v2.html)


### PR DESCRIPTION
in order to render the links correctly, see https://docs.podlove.org/podlove-web-player/

The link for the v4 is https://docs.podlove.org/podlove-web-player/docs.podlove.org/podlove-web-player-v4/