### PR TITLE
Fixvorschlag für #653-Volume bar is not customizable

### DIFF
--- a/apps/player/src/components/volume-control/VolumeControl.vue
+++ b/apps/player/src/components/volume-control/VolumeControl.vue
@@ -22,6 +22,7 @@
           :step="1"
           :background="color"
           :borderColor="color"
+          :progressColor="progressColor"
           @input="setVolume"
           :aria-label="$t(volumeLabel.key, volumeLabel.attr)"
         )
@@ -54,6 +55,7 @@ export default {
     muted: select.audio.muted,
     icon: select.audio.icon,
     color: select.theme.brandDark,
+    progressColor: select.theme.brandDark,
     background: select.theme.brandLightest,
     buttonTitle: select.accessibility.volumeButton,
     volumeLabel: select.accessibility.volumeControl

--- a/packages/components/src/components/input-slider/InputSlider.vue
+++ b/packages/components/src/components/input-slider/InputSlider.vue
@@ -10,7 +10,7 @@
       @change="handleChange"
       @dblclick="handleDblclick"
     />
-    <span class="track" />
+    <span class="track" :style="trackStyle" />
     <span
       v-for="(pin, index) in pins"
       :key="index"
@@ -25,6 +25,7 @@
 </template>
 
 <script>
+import color from 'color'
 import { pluck } from 'ramda'
 import { round } from '@podlove/utils/math'
 
@@ -65,10 +66,20 @@ export default {
     borderColor: {
       type: String,
       default: defaultColors.color
+    },
+    progressColor: {
+      type: String,
+      default: defaultColors.color
     }
   },
 
   computed: {
+    trackStyle() {
+      return {
+        'background-color': color(this.progressColor).fade(0.7)
+      }
+    },
+
     thumbStyle() {
       const left = relativePosition(this.value, this.min, this.max)
       return {

--- a/packages/components/src/components/input-slider/__snapshots__/input-slider.test.js.snap
+++ b/packages/components/src/components/input-slider/__snapshots__/input-slider.test.js.snap
@@ -13,6 +13,7 @@ exports[`InputSlider props should render type 'background' 1`] = `
    
   <span
     class="track"
+    style="background-color: rgba(255, 255, 255, 0.30000000000000004);"
   />
     
   <span
@@ -36,6 +37,7 @@ exports[`InputSlider props should render type 'borderColor' 1`] = `
    
   <span
     class="track"
+    style="background-color: rgba(255, 255, 255, 0.30000000000000004);"
   />
     
   <span
@@ -59,6 +61,7 @@ exports[`InputSlider props should render type 'pins' 1`] = `
    
   <span
     class="track"
+    style="background-color: rgba(255, 255, 255, 0.30000000000000004);"
   />
    
   <span
@@ -86,6 +89,30 @@ exports[`InputSlider props should render type 'pins' 1`] = `
 </div>
 `;
 
+exports[`InputSlider props should render type 'progressColor' 1`] = `
+<div
+  class="input-slider"
+>
+  <input
+    max="20"
+    min="1"
+    step="0.1"
+    type="range"
+  />
+   
+  <span
+    class="track"
+    style="background-color: rgba(255, 255, 255, 0.30000000000000004);"
+  />
+    
+  <span
+    class="thumb"
+    style="left: -5.2631578947368425%; background-color: rgb(43, 138, 198); border-color: #fff;"
+  />
+   
+</div>
+`;
+
 exports[`InputSlider props should render type 'step' 1`] = `
 <div
   class="input-slider"
@@ -99,6 +126,7 @@ exports[`InputSlider props should render type 'step' 1`] = `
    
   <span
     class="track"
+    style="background-color: rgba(255, 255, 255, 0.30000000000000004);"
   />
     
   <span
@@ -122,6 +150,7 @@ exports[`InputSlider props should render type 'value' 1`] = `
    
   <span
     class="track"
+    style="background-color: rgba(255, 255, 255, 0.30000000000000004);"
   />
     
   <span
@@ -145,6 +174,7 @@ exports[`InputSlider props should render without props 1`] = `
    
   <span
     class="track"
+    style="background-color: rgba(255, 255, 255, 0.30000000000000004);"
   />
     
   <span

--- a/packages/components/src/components/input-slider/input-slider.test.js
+++ b/packages/components/src/components/input-slider/input-slider.test.js
@@ -45,6 +45,10 @@ describe('InputSlider', () => {
       {
         prop: 'borderColor',
         value: '#fff'
+      },
+      {
+        prop: 'progressColor',
+        value: '#fff'
       }
     ]
 


### PR DESCRIPTION
VolumeControl reicht die Farbe brandDark an den InputSlider durch. Dort wird
die Farbe mit Hilfe des Alphakanals abgeschwächt.