### PR TITLE
fix: thumb position for progress and ghost

### DIFF
--- a/packages/components/src/components/progress-bar/ProgressBar.vue
+++ b/packages/components/src/components/progress-bar/ProgressBar.vue
@@ -285,7 +285,7 @@ export default {
   position: absolute;
   border: 1px solid;
   // border offset
-  margin-left: -1px;
+  margin-left: calc(-1px - #{$thumb-size / 2});
   height: $thumb-size;
   border-radius: $thumb-size;
   top: calc(50% - #{$thumb-size / 2});
@@ -307,7 +307,7 @@ export default {
   position: absolute;
   border: 1px solid transparent;
   opacity: 0.8;
-  margin-left: -1px;
+  margin-left: calc(-1px - #{$thumb-size / 2});
   height: $thumb-size;
   border-radius: $thumb-size;
   top: calc(50% - #{$thumb-size / 2});


### PR DESCRIPTION
The center of the thumb should be the on the calculated time. Currently the left edge of the thumb is on the calculated time instead. It's most notable at the end of the progress, where the ghost sits _next to_ the timeline instead of on it. Shifting it to the left by half its size fixes this.