### PR TITLE
feat(web-player): add shownotes tab to xl template

### DIFF
--- a/apps/web-player/src/templates/variant-xl.html
+++ b/apps/web-player/src/templates/variant-xl.html
@@ -70,6 +70,9 @@
     <divider class="w-full mt-6 mb-3"></divider>
     <div class="flex justify-between">
       <div class="flex mobile:w-full tablet:w-3/12 desktop:w-3/12 justify-between">
+        <tab-trigger tab="shownotes">
+          <icon type="info"></icon>
+        </tab-trigger>
         <tab-trigger tab="chapters">
           <icon type="chapter"></icon>
         </tab-trigger>
@@ -90,6 +93,9 @@
     </div>
   </div>
   <div class="w-full relative overflow-hidden">
+    <tab name="shownotes">
+      <tab-shownotes></tab-shownotes>
+    </tab>
     <tab name="chapters">
       <tab-chapters></tab-chapters>
     </tab>


### PR DESCRIPTION
I noticed that there is no info / shownote tab anymore like in v4. This PR adds the tab again. The shownote component was added in ([978d8b0](https://github.com/podlove/podlove-ui/commit/978d8b05f2676ef9851c0ad24a19a8ec7e3ebdb5)), but was not added to the web-player template