### PR TITLE
Types: Fix function type

### DIFF
--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -7,7 +7,7 @@ TypeScript type definitions for Podlove Framework.
 Install the types with
 
 ```bash
-npm install D --save-dev
+npm install @podlove/types --save-dev
 ```
 
 ## Embedded Web Player

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -4,7 +4,6 @@
   "description": "TypeScript type definitions for Podlove Framework",
   "homepage": "https://github.com/podlove/ui/tree/development/packages/types",
   "main": "index.js",
-
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/packages/types/web-player.d.ts
+++ b/packages/types/web-player.d.ts
@@ -22,8 +22,8 @@ import { PodloveWebPlayerStore } from './store';
  *
  * @returns store - Promise returning a redux store
  */
-export type podlovePlayer = function(
+export type podlovePlayer = (
   selector: string | Node,
   episode: string | PodloveWebPlayerEpisode,
   configuration: string | any // TODO configuration type
-): Promise<PodloveWebPlayerStore>;
+) => Promise<PodloveWebPlayerStore>;


### PR DESCRIPTION
Hi,
I have now tested the package "@podlove/types" by [adding the package to my project workspace](https://github.com/ribajs/riba/compare/master...ribajs:podcast-types?). There was an error with the function type and I noticed an misstake in the README.

With this changes the package types are working.

Changes
* Add missing package name to README.md
* Fix function type