### PR TITLE
Web player: stop click event propagation on chapter links

### DIFF
--- a/packages/components/src/components/chapter-progress/ChapterProgress.vue
+++ b/packages/components/src/components/chapter-progress/ChapterProgress.vue
@@ -115,6 +115,7 @@ const linkLeave = () => {
         target="_blank"
         @mouseover="linkOver"
         @mouseleave="linkLeave"
+        @click.stop
       >
         {{ chapter.linkTitle }}
       </a>


### PR DESCRIPTION
Before this change, a click on a chapter link did propagate to its parents as well, in particular, the chapter. Clicking on the chapter link therefore also started playback at the chapter. I think it is far more likely that a user clicking on a chapter link intends to open the link rather than wanting to open the link *and* start the chapter as well.

As this is a very small change, I directly opened a PR. Feel free to close this if you want to retain the original behaviour.